### PR TITLE
Fix D64Renderer

### DIFF
--- a/C64.FrontEnd/Helpers/CustomD64Renderer.cs
+++ b/C64.FrontEnd/Helpers/CustomD64Renderer.cs
@@ -37,7 +37,7 @@ namespace C64.FrontEnd.Helpers
                             var srcRectangle = new Rectangle(8 * (source % 16), 8 * (source / 16), 8, 8);
                             var dstRectangle = new Rectangle(8 * i, 8 * current, 8, 8);
 
-                            if (current == 0 && i > 1)
+                            if (current == 0 && i > 1 && srcRectangle.Y < 64)
                                 srcRectangle.Y += 64;
 
                             var toPlot = Extract(charsImage, srcRectangle);


### PR DESCRIPTION
Fix the D64-Render, which crashed on certain characters.